### PR TITLE
#63 Fix: footer 수정

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,25 +1,39 @@
 import React from 'react';
 import Github from '@/assets/icon/footerGithub.svg?react';
 
-const Footer: React.FC = () => {
+interface FooterProps {
+  isMainPage?: boolean;
+}
+
+const Footer: React.FC<FooterProps> = ({ isMainPage = false }) => {
   return (
-    <footer className="w-full h-[236px] flex text-white py-7">
-      <div className="justify-between items-start px-9">
-        <div className="flex items-center space-x-2">
+    <footer
+      className={`w-full ${
+        isMainPage ? 'h-[236px]' : 'h-[143px]'
+      } flex text-white text-center py-7 items-center justify-center`}
+    >
+      <div className="px-9">
+        <div className="flex justify-center items-center space-x-2">
           <span className="font-staatliches text-body">COMMITATO</span>
           <Github />
         </div>
 
         <div className="flex-col text-button text-grey mt-[5%] space-y-3">
-          <p>
-            대표 | 가천대학교 Leets 동아리 내 commitato 팀 &nbsp; &nbsp; &nbsp;
-            &nbsp;사이트명 | Commitato
-          </p>
-          <p>
-            주소 | 가천대학교 글로벌캠퍼스 : (13120) 경기도 성남시 수정구
-            성남대로 1342
-          </p>
-          <p>본 사이트에 게재된 개인 정보 및 작업물의 무단 도용을 금합니다.</p>
+          {isMainPage && (
+            <div className="flex-col text-button text-grey mt-[5%] space-y-3">
+              <p>
+                대표 | 가천대학교 Leets 동아리 내 commitato 팀 &nbsp; &nbsp;
+                사이트명 | Commitato
+              </p>
+              <p>
+                주소 | 가천대학교 글로벌캠퍼스 : (13120) 경기도 성남시 수정구
+                성남대로 1342
+              </p>
+              <p>
+                본 사이트에 게재된 개인 정보 및 작업물의 무단 도용을 금합니다.
+              </p>
+            </div>
+          )}
           <p>Copyright 2024. Commitato all rights reserved.</p>
         </div>
       </div>

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -1,5 +1,14 @@
+import Footer from '@/components/Footer';
+import Header from '@/components/Header';
+
 const MainPagae = () => {
-  return <>main</>;
+  return (
+    <>
+      <Header />
+      main
+      <Footer isMainPage={true} />
+    </>
+  );
 };
 
 export default MainPagae;


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?

<br>

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.
<img width="1710" alt="image" src="https://github.com/user-attachments/assets/54bba1c2-a500-40f4-919b-fa46cd0b3156" />
<img width="1710" alt="image" src="https://github.com/user-attachments/assets/a97068e0-360e-45ce-91fd-021c9390dca4" />

<br>

## 4. 완료 사항
- MainPage인지 아닌지로 구별을 하여서 footer의 UI 수정을 하였습니다
- 기존에 글자가 왼쪽 정렬이었던 점과 Footer의 중간 정렬로 수정하였습니다
<br>

## 5. 추가 사항
`mainpage`에 `header`와 `footer` 설정해두었습니다!
<br>
