### PR TITLE
#94 Fix: qa 수정사항 반영

### DIFF
--- a/src/components/modal/LoginLoadingModal.tsx
+++ b/src/components/modal/LoginLoadingModal.tsx
@@ -11,7 +11,7 @@ const LoginLoadingModal = () => {
       <div className="w-8 h-8 border-2 border-black border-t-transparent rounded-full animate-spin" />
       <br />
       <div className="font-Regular text-small leading-relaxed">
-        GITHUB
+        GitHub
         <GithubSVG className="inline-block mx-1 mb-1" />
         에서 정보를 가져오는 중입니다.
         <br />

--- a/src/components/myPage/MyCommitFarm.tsx
+++ b/src/components/myPage/MyCommitFarm.tsx
@@ -33,7 +33,7 @@ const MyCommitFarm = ({ isLoading, className = '' }: MyCommitFarmProps) => {
       }
     };
     fetchData();
-  }, [githubId]);
+  }, [finalGithubId]);
 
   if (isLoading) {
     return (

--- a/src/components/myPage/ProfileCard.tsx
+++ b/src/components/myPage/ProfileCard.tsx
@@ -79,10 +79,15 @@ const ProfileCard = ({
 
     const diffInMs = now.getTime() - pastDate.getTime();
     const diffInHours = Math.floor(diffInMs / (1000 * 60 * 60));
+    const diffInDays = Math.floor(diffInHours / 24);
 
-    return diffInHours > 0
-      ? `${diffInHours}시간 전`
-      : formatDistanceToNow(pastDate, { addSuffix: true, locale: ko });
+    if (diffInDays > 0) {
+      return `${diffInDays}일 전`;
+    } else if (diffInHours > 0) {
+      return `${diffInHours}시간 전`;
+    } else {
+      return formatDistanceToNow(pastDate, { addSuffix: true, locale: ko });
+    }
   };
 
   return (

--- a/src/pages/myPage/index.tsx
+++ b/src/pages/myPage/index.tsx
@@ -44,7 +44,7 @@ const MyPage = () => {
         {userData ? (
           <>
             <p className="font-staatliches text-header">
-              {githubId ? `${githubId}'s PAGE` : 'MY PAGE'}
+              {isMyPage ? 'MY PAGE' : `${githubId}'s PAGE`}
             </p>
             <Line />
           </>


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
#94 를 구현하였습니다.
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
마이페이지에서 Today Commit 수는 불러와지는데 현재 농장 캘린더에서 당일의 캘린더는 서버에서 보내주지 않고 있어서 해당 부분은 다음 회의때 얘기해보면 좋을 것 같아요!
<br>

## 3. 관련 스크린샷을 첨부해주세요.
UI적으로 변경사항이 없어서 스크린샷은 첨부하지 않았습니다.
<br>

## 4. 완료 사항
- 마이페이지 update 최근 업데이트 시간 -> 시간+일 로 변경
- 마이페이지 캘린더 새로고침 후 불러와지는 것 useEffect 의존성 추가로 수정
- GITHUB 모달에서 GitHub 폰트로 수정 
- 랭킹페이지에서 자신의 페이지 클릭시 MYPAGE로 보이도록 수정
<br>

## 5. 추가 사항
찾아봤는데 GITHUB 공식 폰트는 사용하지 못하여서 일단 대소문자만 수정해두었습니다!
<br>
